### PR TITLE
Replaced hard-coded http protocol in JS lib links

### DIFF
--- a/src/main/webapp/WEB-INF/views/pcfdemo.jsp
+++ b/src/main/webapp/WEB-INF/views/pcfdemo.jsp
@@ -128,15 +128,15 @@
 	
     <div class="container">
         <div class="footer">
-          <div class="footer-text">©&nbsp;2014 Pivotal Software, Inc.  </div>
+          <div class="footer-text">Â©&nbsp;2014 Pivotal Software, Inc.  </div>
           <div class="footer-poweredby"><img src="resources/img/PoweredByPivotal.png" alt="Powered By Pivotal "></div>
 	    </div>
 	</div>  		
   		
 
 
-  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
-<script src="http://d3js.org/d3.v2.min.js?2.9.6"></script>
+<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/d3/2.10.0/d3.v2.min.js"></script>
 <script src="resources/js/rainbowvis.js"></script>
 
 <script src="/resources/js/histograms.js"></script>


### PR DESCRIPTION
Also updated d3 from 2.9.6 to 2.10.0 (due to availability over public, https-supporting CDN) -- hopefully that doesn't break anything.

See https://github.com/Pivotal-Field-Engineering/PCF-demo/issues/2

Note: haven't tested yet due to maven failing over the poor wifi here at http://www.pivotal.io/platform-as-a-service/cloud-platform-roadshow/minneapolis
