### PR TITLE
Updating spring cloud connector libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,6 @@
 	</properties>
 	<dependencies>
 
-
-
       <dependency>
           <groupId>org.springframework.amqp</groupId>
           <artifactId>spring-rabbit</artifactId>
@@ -59,22 +57,14 @@
 		<dependency>
 		    <groupId>org.springframework.cloud</groupId>
 		    <artifactId>spring-service-connector</artifactId>
-		    <version>0.9.2</version>
+		    <version>1.2.0.RELEASE</version>
 		</dependency>
 		<!-- If you intend to deploy the app on Cloud Foundry, add the following -->
 		<dependency>
 		    <groupId>org.springframework.cloud</groupId>
 		    <artifactId>cloudfoundry-connector</artifactId>
-		    <version>0.9.2</version>
+		    <version>1.2.0.RELEASE</version>
 		</dependency>		
-		
-		<!-- 
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-orm</artifactId>
-			<version>${org.springframework-version}</version>
-		</dependency>
-		 -->
 
 		<!-- AspectJ -->
 		<dependency>
@@ -207,14 +197,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.5.1</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-					<compilerArgument>-Xlint:all</compilerArgument>
-					<showWarnings>true</showWarnings>
-					<showDeprecation>true</showDeprecation>
-				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
The app uses a pretty old version of spring-cloud-connectors library the class used to instantiate the connection RabbitServiceInfoCreator has been deleted in the latest released and replaced with the AmqpServiceInfoCreator
​
This is the class that should be used
https://github.com/spring-cloud/spring-cloud-connectors/blob/master/spring-cloud-cloudfoundry-connector/src/main/java/org/springframework/cloud/cloudfoundry/AmqpServiceInfoCreator.java

My commit updates the spring-cloud-connector and spring-cloud-services libraries to the latest release. Without the latest spring-cloud libraries PCF demo cannot talk amqps to a RabbitMQ broker that is SSL enabled. 

The following exception is seen:
```java
2015-12-10T13:20:44.40-0500 [APP/0]      OUT Caused by: java.lang.IllegalArgumentException: wrong scheme in amqp URI: amqps://f3658df4-0a67-48c6-8277-69ac79b71d82:6des31ofqp79t5dj1nhimbshep@192.168.200.78/df2a3939-e9bb-4ba9-b149-5332b513c27e
2015-12-10T13:20:44.40-0500 [APP/0]      OUT 	at org.springframework.cloud.service.common.RabbitServiceInfo.validateAndCleanUriInfo(RabbitServiceInfo.java:32)
2015-12-10T13:20:44.40-0500 [APP/0]      OUT 	at org.springframework.cloud.service.UriBasedServiceInfo.<init>(UriBasedServiceInfo.java:24)
2015-12-10T13:20:44.40-0500 [APP/0]      OUT 	at org.springframework.cloud.service.UriBasedServiceInfo.<init>(UriBasedServiceInfo.java:19)
2015-12-10T13:20:44.40-0500 [APP/0]      OUT 	at org.springframework.cloud.service.common.RabbitServiceInfo.<init>(RabbitServiceInfo.java:21)
2015-12-10T13:20:44.40-0500 [APP/0]      OUT 	at org.springframework.cloud.cloudfoundry.RabbitServiceInfoCreator.createServiceInfo(RabbitServiceInfoCreator.java:26)
2015-12-10T13:20:44.40-0500 [APP/0]      OUT 	at org.springframework.cloud.cloudfoundry.RabbitServiceInfoCreator.createServiceInfo(RabbitServiceInfoCreator.java:12)
2015-12-10T13:20:44.40-0500 [APP/0]      OUT 	at org.springframework.cloud.AbstractCloudConnector.getServiceInfo(AbstractCloudConnector.java:61)
2015-12-10T13:20:44.40-0500 [APP/0]      OUT 	at org.springframework.cloud.AbstractCloudConnector.getServiceInfos(AbstractCloudConnector.java:40)
2015-12-10T13:20:44.40-0500 [APP/0]      OUT 	at org.springframework.cloud.Cloud.getServiceInfos(Cloud.java:89)
2015-12-10T13:20:44.40-0500 [APP/0]      OUT 	at com.pivotal.example.xd.RabbitClient.<init>(RabbitClient.java:48)
2015-12-10T13:20:44.40-0500 [APP/0]      OUT 	at com.pivotal.example.xd.RabbitClient.getInstance(RabbitClient.java:101)
2015-12-10T13:20:44.40-0500 [APP/0]      OUT 	at com.pivotal.example.xd.controller.OrderController.<init>(OrderController.java:47)
2015-12-10T13:20:44.40-0500 [APP/0]      OUT 	at sun.reflect.GeneratedConstructorAccessor47.newInstance(Unknown Source)
2015-12-10T13:20:44.40-0500 [APP/0]      OUT 	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
2015-12-10T13:20:44.40-0500 [APP/0]      OUT 	at java.lang.reflect.Constructor.newInstance(Constructor.java:422)
2015-12-10T13:20:44.40-0500 [APP/0]      OUT 	at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:147)
2015-12-10T13:20:44.40-0500 [APP/0]      OUT 	... 39 more
```




